### PR TITLE
use PluginManagerEx.convertEscapeCharacters in MZ

### DIFF
--- a/plugins/achievement/config/main.ts
+++ b/plugins/achievement/config/main.ts
@@ -132,7 +132,7 @@ const createBase = (options: {
   pluginCommandDescription?: string | I18nText;
   addParams?: TorigoyaPluginConfigSchema['params'];
 }): Partial<TorigoyaPluginConfigSchema> => ({
-  version: '1.7.0',
+  version: '1.8.0',
   title: {
     ja: '実績プラグイン',
   },

--- a/plugins/achievement/src/TorigoyaMZ_Achievement2.js
+++ b/plugins/achievement/src/TorigoyaMZ_Achievement2.js
@@ -199,9 +199,14 @@ class Window_AchievementList extends Window_Selectable {
     this.resetTextColor();
     this.changePaintOpacity(!!achievementItem);
 
+    const name =
+      typeof PluginManagerEx !== 'undefined' && PluginManagerEx.convertEscapeCharacters
+        ? PluginManagerEx.convertEscapeCharacters(item.name)
+        : item.name;
+
     const iconWidth = ImageManager.iconWidth + 8;
     this.drawIcon(item.iconIndex, rect.x, rect.y + (rect.height - ImageManager.iconHeight) / 2);
-    this.drawText(item.name, rect.x + iconWidth, rect.y, rect.width - iconWidth, 'left');
+    this.drawText(name, rect.x + iconWidth, rect.y, rect.width - iconWidth, 'left');
   }
 
   refresh() {


### PR DESCRIPTION
## before

<img width="613" alt="20240119_015415_nw_FgP1GVQFMa" src="https://github.com/rutan/torigoya-rpg-maker-plugin/assets/1131422/938d7feb-15d3-4237-9cfc-a0b2e5166bf0">

## after

<img width="612" alt="20240119_015345_nw_Nr3KndeKvn" src="https://github.com/rutan/torigoya-rpg-maker-plugin/assets/1131422/68f38304-d3f9-49bf-8d2a-a1efbdc408a1">
