### PR TITLE
fix deactivate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # v.2.4.0
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v.4.0.0
         with:
           run_install: false
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,7 +19,7 @@ jobs:
           ref: main
           path: main
 
-      - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # v.2.4.0
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v.4.0.0
         with:
           run_install: false
           package_json_file: 'main/package.json'

--- a/plugins/bookshelf/config.ts
+++ b/plugins/bookshelf/config.ts
@@ -80,7 +80,7 @@ const structMenuItem = createStruct('MenuItem', [
 ]);
 
 const base: Partial<TorigoyaPluginConfigSchema> = {
-  version: '1.2.1',
+  version: '1.2.2',
   title: {
     ja: 'テキスト本棚プラグイン',
   },

--- a/plugins/bookshelf/src/TorigoyaMZ_Bookshelf.js
+++ b/plugins/bookshelf/src/TorigoyaMZ_Bookshelf.js
@@ -487,6 +487,7 @@ class Scene_Bookshelf extends Scene_MenuBase {
 
   onBookContentCancel() {
     this._bookContentWindow.close();
+    this._bookContentWindow.deactivate();
     this._booksListWindow.activate();
   }
 

--- a/plugins/bookshelf/src/Torigoya_Bookshelf.js
+++ b/plugins/bookshelf/src/Torigoya_Bookshelf.js
@@ -451,6 +451,7 @@ class Scene_Bookshelf extends Scene_MenuBase {
 
   onBookContentCancel() {
     this._bookContentWindow.close();
+    this._bookContentWindow.deactivate();
     this._booksListWindow.activate();
   }
 }


### PR DESCRIPTION
> こんにちは！Ruたんさまの「Torigoya_Bookshelf」（ツクールMZ版)について質問させていただきます。
新規プロジェクトで導入してみました。
１つの本（項目）をクリックしながら最後まで読み終わり、最後のページでクリックすると、本が閉じて本棚に戻りますが、左上に「ページ送りアイコン」が残ったままになってしまいます。最初に本棚を開いた時のように、本を開くまでは本棚に「ページ送りアイコン」が表示されないようにするにはどうすれば良いでしょうか？

bookContentWindow の deactivate 漏れで、閉じたあとも裏で active になってたためのを修正。